### PR TITLE
changing options.vpc to options.network

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -123,9 +123,9 @@ class ServerlessFargateTasks {
           'TaskDefinition': {"Fn::Sub": '${' + name + 'Task}'},
           'NetworkConfiguration': {
             'AwsvpcConfiguration': Object.assign({
-              'AssignPublicIp': options.vpc['public-ip'] || "DISABLED",
-              'SecurityGroups': options.vpc['security-groups'] || [],
-              'Subnets': options.vpc['subnets'] || [],
+              'AssignPublicIp': options.network['public-ip'] || "DISABLED",
+              'SecurityGroups': options.network['security-groups'] || [],
+              'Subnets': options.network['subnets'] || [],
             }, network_override),
           }
         }, service_override)


### PR DESCRIPTION
My apologies in advance for the bikeshedding here. 

In the readme for the project the ECS service networking details are configured under custom, fargate, network.

However the serverless plugin itself is looking for settings under custom, fargate, vpc.

I've changed the plugin to look for config settings under network to match the readme. I can easily just change the pull request to change the readme if you'd prefer that.