### PR TITLE
Handling zero desired task count

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -112,6 +112,8 @@ class ServerlessFargateTasks {
       }
       template['Resources'][name + 'Task'] = task
 
+      let desired = options.tasks[identifier]['desired']
+
       // create the service definition
       var service = {
         'Type': 'AWS::ECS::Service',
@@ -119,7 +121,7 @@ class ServerlessFargateTasks {
           'Cluster': {"Fn::Sub": '${FargateTasksCluster}'},
           'LaunchType': 'FARGATE',
           'ServiceName': identifier,
-          'DesiredCount': options.tasks[identifier]['desired'] || 1,
+          'DesiredCount': desired == undefined ? 1 : desired,
           'TaskDefinition': {"Fn::Sub": '${' + name + 'Task}'},
           'NetworkConfiguration': {
             'AwsvpcConfiguration': Object.assign({


### PR DESCRIPTION
We are manually triggering Fargate tasks to handle long running lambda-like workloads. To achieve this, we set the number of desired instances to zero. Fargate supports this configuration, but the current implementation would for a zero desired count to 1. This retains the current behavior in all cases except for an explicit zero.