### PR TITLE
feature: allowing to customize task name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ custom:
 
     tasks:
       my-task:
+        name: ${self:service}-${self:provider.stage}-my-task # default name is be the object key (here 'my-task')
         image: 123456789369.dkr.ecr.eu-west-1.amazonaws.com/my-image
         environment:  # optional
           platypus: true

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,10 +35,7 @@ class ServerlessFargateTasks {
     // for each defined task, we create a service and a task, and point it to
     // the created cluster
     Object.keys(options.tasks).forEach(identifier => {
-      var name = this.provider.naming.normalizeNameToAlphaNumericOnly(identifier);
       if (debug) consoleLog(yellow('Processing ' + identifier));
-      // consoleLog(identifier);
-      // consoleLog(name);
       // consoleLog(options.tasks[identifier]);
 
       // get all override values, if they exists
@@ -47,6 +44,9 @@ class ServerlessFargateTasks {
       var task_override = override['task'] || {}
       var service_override = override['service'] || {}
       var network_override = override['network'] || {}
+
+      var name = options.tasks[identifier]['name'] || identifier
+      var normalizedIdentifier = this.provider.naming.normalizeNameToAlphaNumericOnly(identifier)
 
       // consoleLog(override);
       if (!override.hasOwnProperty('role')) {
@@ -84,7 +84,7 @@ class ServerlessFargateTasks {
 
       // create the container definition
       var definitions = Object.assign({
-        'Name': identifier,
+        'Name': name,
         'Image': options.tasks[identifier]['image'],
         'Environment': environment,
         'LogConfiguration': {
@@ -102,7 +102,7 @@ class ServerlessFargateTasks {
         'Type': 'AWS::ECS::TaskDefinition',
         'Properties': Object.assign({
           'ContainerDefinitions': [definitions],
-          'Family': identifier,
+          'Family': name,
           'NetworkMode': 'awsvpc',
           'ExecutionRoleArn': options['role'] || {"Fn::Sub": 'arn:aws:iam::${AWS::AccountId}:role/ecsTaskExecutionRole'},
           'TaskRoleArn': override['role'] || {"Fn::Sub": '${IamRoleLambdaExecution}'},
@@ -111,7 +111,7 @@ class ServerlessFargateTasks {
           'Cpu': options.tasks[identifier]['cpu'] || 256,
         }, task_override)
       }
-      template['Resources'][name + 'Task'] = task
+      template['Resources'][normalizedIdentifier + 'Task'] = task
 
       let desired = options.tasks[identifier]['desired']
 
@@ -121,9 +121,9 @@ class ServerlessFargateTasks {
         'Properties': Object.assign({
           'Cluster': {"Fn::Sub": '${FargateTasksCluster}'},
           'LaunchType': 'FARGATE',
-          'ServiceName': identifier,
+          'ServiceName': name,
           'DesiredCount': desired == undefined ? 1 : desired,
-          'TaskDefinition': {"Fn::Sub": '${' + name + 'Task}'},
+          'TaskDefinition': {"Fn::Sub": '${' + normalizedIdentifier + 'Task}'},
           'NetworkConfiguration': {
             'AwsvpcConfiguration': Object.assign({
               'AssignPublicIp': options.vpc['public-ip'] || "DISABLED",
@@ -133,7 +133,7 @@ class ServerlessFargateTasks {
           }
         }, service_override)
       }
-      template['Resources'][name + 'Service'] = service
+      template['Resources'][normalizedIdentifier + 'Service'] = service
     });
 
     function yellow(str) {


### PR DESCRIPTION
Fixes #4 
- If no name is provided, then we keep the identifier, as before.
- The resource names (task name, family name, service name) are normalized, while the `Name` resources properties aren't.

I have been able to deploy the service with 2 different stages on the same account :)
Let me know if I missed something