### PR TITLE
Allow to skip ECS Service creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ custom:
           myArn: #{MyResource.Arn}
         cpu: 512  # optional, defaults to 25% -> 256, see cloudformation docs for valid values
         memory: 1GB  # optional, defaults to 0.5GB
+        noService: true # optional, defaults to false.
+                        # If set to `true`, will not create ECS service - tasks may then be executed using AWS API via `run-task`instead.
 ```
 
 Advanced usage

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ class ServerlessFargateTasks {
       let desired = options.tasks[identifier]['desired']
 
       // create the service definition
-      if (!options.tasks[identifier]) {
+      if (!options.tasks[identifier].noService) {
         const service = {
           'Type': 'AWS::ECS::Service',
           'Properties': Object.assign({

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ class ServerlessFargateTasks {
       let desired = options.tasks[identifier]['desired']
 
       // create the service definition
-      if (!options.noService) {
+      if (!options.tasks[identifier]) {
         const service = {
           'Type': 'AWS::ECS::Service',
           'Properties': Object.assign({

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,24 +110,26 @@ class ServerlessFargateTasks {
       let desired = options.tasks[identifier]['desired']
 
       // create the service definition
-      var service = {
-        'Type': 'AWS::ECS::Service',
-        'Properties': Object.assign({
-          'Cluster': {"Fn::Sub": '${FargateTasksCluster}'},
-          'LaunchType': 'FARGATE',
-          'ServiceName': name,
-          'DesiredCount': desired == undefined ? 1 : desired,
-          'TaskDefinition': {"Fn::Sub": '${' + normalizedIdentifier + 'Task}'},
-          'NetworkConfiguration': {
-            'AwsvpcConfiguration': Object.assign({
-              'AssignPublicIp': options.vpc['public-ip'] || "DISABLED",
-              'SecurityGroups': options.vpc['security-groups'] || [],
-              'Subnets': options.vpc['subnets'] || [],
-            }, network_override),
-          }
-        }, service_override)
+      if (!options.noService) {
+        const service = {
+          'Type': 'AWS::ECS::Service',
+          'Properties': Object.assign({
+            'Cluster': {"Fn::Sub": '${FargateTasksCluster}'},
+            'LaunchType': 'FARGATE',
+            'ServiceName': name,
+            'DesiredCount': desired == undefined ? 1 : desired,
+            'TaskDefinition': {"Fn::Sub": '${' + normalizedIdentifier + 'Task}'},
+            'NetworkConfiguration': {
+              'AwsvpcConfiguration': Object.assign({
+                'AssignPublicIp': options.vpc['public-ip'] || "DISABLED",
+                'SecurityGroups': options.vpc['security-groups'] || [],
+                'Subnets': options.vpc['subnets'] || [],
+              }, network_override),
+            }
+          }, service_override)
+        }
+        template['Resources'][normalizedIdentifier + 'Service'] = service
       }
-      template['Resources'][normalizedIdentifier + 'Service'] = service
     });
 
     function yellow(str) {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
   },
   "scripts": {
   },
-  "version": "0.4.1"
+  "version": "0.5"
 }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
   },
   "scripts": {
   },
-  "version": "0.5"
+  "version": "0.5.0"
 }


### PR DESCRIPTION
Added an option to skip ECS Service creation.  
It is helpful for cases where one wishes to run the generated task definition in the generated cluster using AWS API instead of having a long running service.