### PR TITLE
Override Cluster Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ You can override the generated CF resource properties per task with the `overrid
 ```
 custom:
   fargate:
+    override:
+        cluster:
+            Foo: bar
+
     tasks:
       my-task:
         image: 123456789369.dkr.ecr.eu-west-1.amazonaws.com/my-image

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,9 +22,12 @@ class ServerlessFargateTasks {
 
     if (debug) consoleLog(yellow('Fargate Tasks Plugin'));
 
+    const clusterOverride = options.override && options.override.cluster || {};
+
     // add the cluster
     template['Resources']['FargateTasksCluster'] = {
       "Type" : "AWS::ECS::Cluster",
+      ...clusterOverride
     }
 
     // Create a loggroup for the logs


### PR DESCRIPTION
Just like overriding task, container and other properties it would be useful to override the cluster properties