### PR TITLE
Feature/add elb resource suppport

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ custom:
           myArn: #{MyResource.Arn}
         cpu: 512  # optional, defaults to 25% -> 256, see cloudformation docs for valid values
         memory: 1GB  # optional, defaults to 0.5GB
+        noService: true # optional, defaults to false.
+                        # If set to `true`, will not create ECS service - tasks may then be executed using AWS API via `run-task`instead.
 ```
 
 Advanced usage

--- a/README.md
+++ b/README.md
@@ -66,10 +66,18 @@ custom:
       my-task-with-load-balancers:
         image: 123456789369.dkr.ecr.eu-west-1.amazonaws.com/my-image
         loadBalancers:
-          - port: 8080
+          # You can use the arn of an existing target group already associated with a load balancer
+          - hostPort: 8080
+            containerPort: 8080
             arn: ${self:custom.httpTargetGroupArn}
-          - port 8443
-            arn: ${self:custom.httpsTargetGroupArn}
+          # If you're using an ELB/target group that you're building in the Resources section of
+          # serverless.yml, you may run into an issue where the elb and default listener rule are
+          # not created prior to the target group/service. In this scenario you can specify the 
+          # logical name of the resource so that the appropriate dependencies can be set.
+          - hostPort: 8443
+            containerPort: 8443
+            arn: ${self:custom.httpsTargetGroupArn} 
+            elbResource: "my-task-elb"
 ```
 
 Advanced usage

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ custom:
           expression: 'cron(0 12 * * ? *)' # See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for more options.
           task-count: 2
           platform-version: 1.4.0 #Defaults to 'LATEST' which is 1.3.0 as of now. 1.3.0 does not support ECS volumes.
+
+      # You can register services with Application or Network Load Balancer target groups
+      my-task-with-load-balancers:
+        image: 123456789369.dkr.ecr.eu-west-1.amazonaws.com/my-image
+        loadBalancers:
+          - port: 8080
+            arn: ${self:custom.httpTargetGroupArn}
+          - port 8443
+            arn: ${self:custom.httpsTargetGroupArn}
 ```
 
 Advanced usage

--- a/README.md
+++ b/README.md
@@ -52,8 +52,15 @@ custom:
           myArn: #{MyResource.Arn}
         cpu: 512  # optional, defaults to 25% -> 256, see cloudformation docs for valid values
         memory: 1GB  # optional, defaults to 0.5GB
-        noService: true # optional, defaults to false.
+        no-service: true # optional, defaults to false.
                         # If set to `true`, will not create ECS service - tasks may then be executed using AWS API via `run-task`instead.
+      
+      my-scheduled-task:
+        image: 123456789369.dkr.ecr.eu-west-1.amazonaws.com/my-image
+        schedule: # If schedule is set, no-service is automatically set to 'true'
+          expression: 'cron(0 12 * * ? *)' # See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for more options.
+          task-count: 2
+          platform-version: 1.4.0 #Defaults to 'LATEST' which is 1.3.0 as of now. 1.3.0 does not support ECS volumes.
 ```
 
 Advanced usage

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,14 +174,21 @@ class ServerlessFargateTasks {
         // Configure Load Balancers if defined.
         if(options.tasks[identifier].hasOwnProperty('loadBalancers')) {
           let loadBalancers = [];
+          let dependsOn = [];
           options.tasks[identifier]['loadBalancers'].forEach(item => {
             const loadBalancer = Object.assign({
               'ContainerName': name,
               'ContainerPort': item.containerPort,
-              'TargetGroupArn': item.arn
+              'TargetGroupArn': item.targetGroup
             });
             loadBalancers.push(loadBalancer);
+            if(item.hasOwnProperty('elbResource')) {
+              dependsOn.push(item.elbResource)
+            }
           });
+          if(dependsOn.length > 0) {
+            service['DependsOn'] = dependsOn;
+          }
           service['Properties']['LoadBalancers'] = loadBalancers;
         }
         template['Resources'][normalizedIdentifier + 'Service'] = service

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,19 @@ class ServerlessFargateTasks {
             'awslogs-stream-prefix': 'fargate'
           },
         },
-      }, container_override)
+      }, container_override);
+  
+      if(options.tasks[identifier].hasOwnProperty('loadBalancers')) {
+        let portMappings= [];
+        options.tasks[identifier]['loadBalancers'].forEach(item => {
+          const portMapping = {
+            'ContainerPort': item.containerPort,
+            'HostPort': item.hostPort
+          };
+          portMappings.push(portMapping);
+        });
+        definitions['PortMappings'] = portMappings;
+      }
 
       // create the task definition
       var task = {
@@ -165,11 +177,12 @@ class ServerlessFargateTasks {
           options.tasks[identifier]['loadBalancers'].forEach(item => {
             const loadBalancer = Object.assign({
               'ContainerName': name,
-              'ContainerPort': item.port,
+              'ContainerPort': item.containerPort,
               'TargetGroupArn': item.arn
             });
             loadBalancers.push(loadBalancer);
           });
+          service['Properties']['LoadBalancers'] = loadBalancers;
         }
         template['Resources'][normalizedIdentifier + 'Service'] = service
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ class ServerlessFargateTasks {
       let desired = options.tasks[identifier]['desired']
 
       // create the service definition
-      if (!options.tasks[identifier]) {
+      if (!options.tasks[identifier].noService) {
         const service = {
           'Type': 'AWS::ECS::Service',
           'Properties': Object.assign({

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ class ServerlessFargateTasks {
       let desired = options.tasks[identifier]['desired']
 
       // create the service definition
-      if (!options.noService) {
+      if (!options.tasks[identifier]) {
         const service = {
           'Type': 'AWS::ECS::Service',
           'Properties': Object.assign({

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,10 +107,41 @@ class ServerlessFargateTasks {
       }
       template['Resources'][normalizedIdentifier + 'Task'] = task
 
+      // create scheduled rule definition
+      if(options.tasks[identifier].hasOwnProperty('schedule')){
+        options.tasks[identifier]['no-service'] = true;
+        var rule = {
+          'Type': 'AWS::Events::Rule',
+          'Properties': Object.assign({
+            'ScheduleExpression': options.tasks[identifier]['schedule']['expression'],
+            'State': 'ENABLED',
+            'Targets': [{
+              'Arn': {"Fn::Sub": '${FargateTasksCluster.Arn}'},
+              'Id': identifier,
+              'RoleArn': options['role'] || {"Fn::Sub": 'arn:aws:iam::${AWS::AccountId}:role/ecsTaskExecutionRole'},
+              'EcsParameters': {
+                'TaskDefinitionArn': {"Fn::Sub": `\${${ normalizedIdentifier }Task}`},
+                'TaskCount': options.tasks[identifier]['schedule']['task-count'] || 1,
+                'LaunchType': 'FARGATE',
+                'PlatformVersion': options.tasks[identifier]['schedule']['platform-version'] || 'LATEST',
+                'NetworkConfiguration': {
+                  'AwsVpcConfiguration': Object.assign({
+                    'AssignPublicIp': options.vpc['public-ip'] || "DISABLED",
+                    'SecurityGroups': options.vpc['security-groups'] || [],
+                    'Subnets': options.vpc['subnets'] || [],
+                  }, network_override),
+                }
+              }
+          }]
+          })
+        }
+        template['Resources'][normalizedIdentifier + 'Rule'] = rule
+      }
+
       let desired = options.tasks[identifier]['desired']
 
       // create the service definition
-      if (!options.tasks[identifier].noService) {
+      if (!options.tasks[identifier]['no-service']) {
         const service = {
           'Type': 'AWS::ECS::Service',
           'Properties': Object.assign({

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,6 +159,18 @@ class ServerlessFargateTasks {
             }
           }, service_override)
         }
+        // Configure Load Balancers if defined.
+        if(options.tasks[identifier].hasOwnProperty('loadBalancers')) {
+          let loadBalancers = [];
+          options.tasks[identifier]['loadBalancers'].forEach(item => {
+            const loadBalancer = Object.assign({
+              'ContainerName': name,
+              'ContainerPort': item.port,
+              'TargetGroupArn': item.arn
+            });
+            loadBalancers.push(loadBalancer);
+          });
+        }
         template['Resources'][normalizedIdentifier + 'Service'] = service
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,24 +110,26 @@ class ServerlessFargateTasks {
       let desired = options.tasks[identifier]['desired']
 
       // create the service definition
-      var service = {
-        'Type': 'AWS::ECS::Service',
-        'Properties': Object.assign({
-          'Cluster': {"Fn::Sub": '${FargateTasksCluster}'},
-          'LaunchType': 'FARGATE',
-          'ServiceName': name,
-          'DesiredCount': desired == undefined ? 1 : desired,
-          'TaskDefinition': {"Fn::Sub": '${' + normalizedIdentifier + 'Task}'},
-          'NetworkConfiguration': {
-            'AwsvpcConfiguration': Object.assign({
-              'AssignPublicIp': options.vpc['public-ip'] || "DISABLED",
-              'SecurityGroups': options.vpc['security-groups'] || [],
-              'Subnets': options.vpc['subnets'] || [],
-            }, network_override),
-          }
-        }, service_override)
+      if (!options.noService) {
+        const service = {
+          'Type': 'AWS::ECS::Service',
+          'Properties': Object.assign({
+            'Cluster': {"Fn::Sub": '${FargateTasksCluster}'},
+            'LaunchType': 'FARGATE',
+            'ServiceName': name,
+            'DesiredCount': desired == undefined ? 1 : desired,
+            'TaskDefinition': {"Fn::Sub": '${' + normalizedIdentifier + 'Task}'},
+            'NetworkConfiguration': {
+              'AwsvpcConfiguration': Object.assign({
+                'AssignPublicIp': options.vpc['public-ip'] || "DISABLED",
+                'SecurityGroups': options.vpc['security-groups'] || [],
+                'Subnets': options.vpc['subnets'] || [],
+              }, network_override),
+            }
+          }, service_override)
+        }
+        template['Resources'][normalizedIdentifier + 'Service'] = service
       }
-      template['Resources'][normalizedIdentifier + 'Service'] = service
     });
 
     function yellow(str) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "bugs": {
-    "url": ""
+    "url": "https://github.com/RoundingWellOS/serverless-fargate-tasks"
   },
   "description": "Run and configure Fargate tasks from within your serverless project",
   "devDependencies": {},
@@ -10,9 +10,9 @@
   "name": "serverless-fargate-tasks",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/svdgraaf/serverless-fargate-tasks.git"
+    "url": "git+https://github.com/RoundingWellOS/serverless-fargate-tasks.git"
   },
   "scripts": {
   },
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
   },
   "scripts": {
   },
-  "version": "0.4.1"
+  "version": "0.5"
 }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
   },
   "scripts": {
   },
-  "version": "0.5"
+  "version": "0.5.0"
 }


### PR DESCRIPTION
Adds ability to specify a Resource Logical name for implementations that create load balancers and target groups within the resource sections of the serverless.yml file. This is important because the CloudFormation update task will fail if the referenced target group is not already associated with an existing ELB. Ultimately, we should probably weigh whether we want to 
1) continue support in this manner. 
2) configure the plugin such that a target group + elb are created VIA the plugin and disable support for pre-existing target groups
or
3) Find a way to both support existing target groups OR have the plugin create a new target group/elb pair and set dependencies accordingly.