### PR TITLE
fix: crash without stackTags

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ class ServerlessFargateTasks {
     template['Resources']['FargateTasksCluster'] = {
       "Type" : "AWS::ECS::Cluster",
       'Properties': {
-        'Tags': Object.entries(this.serverless.service.provider.stackTags).map(function(t) { return {Key: t[0], Value: t[1]}}),
+        'Tags': Object.entries(this.serverless.service.provider.stackTags ?? {}).map(function(t) { return {Key: t[0], Value: t[1]}}),
       }
     }
 
@@ -106,7 +106,7 @@ class ServerlessFargateTasks {
           'RequiresCompatibilities': ['FARGATE'],
           'Memory': options.tasks[identifier]['memory'] || "0.5GB",
           'Cpu': options.tasks[identifier]['cpu'] || 256,
-          'Tags': Object.entries(this.serverless.service.provider.stackTags).map(function(t) { return {Key: t[0], Value: t[1]}}),
+          'Tags': Object.entries(this.serverless.service.provider.stackTags ?? {}).map(function(t) { return {Key: t[0], Value: t[1]}}),
         }, task_override)
       }
 
@@ -135,7 +135,7 @@ class ServerlessFargateTasks {
               'Subnets': options.vpc['subnets'] || [],
             }, network_override),
           },
-          'Tags': Object.entries(this.serverless.service.provider.stackTags).map(function(t) { return {Key: t[0], Value: t[1]}}),
+          'Tags': Object.entries(this.serverless.service.provider.stackTags ?? {}).map(function(t) { return {Key: t[0], Value: t[1]}}),
           'PropagateTags': 'TASK_DEFINITION'
         }, service_override)
       }


### PR DESCRIPTION
Hi @svdgraaf ,

we are not using the stackTags and are not able to use the new Version of this plugin. The reason is:

```
Object.entries(this.serverless.service.provider.stackTags) ->

Object.entries(undefined) ->

TypeError: Cannot convert undefined or null to object
```

Hope this is fix ok for you. We are waiting for the next Version :-)

Have a nice day,
Dennis